### PR TITLE
Remove tautological condition in shared/util

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -290,7 +290,7 @@ func Retry(f func() error, attempts uint) error {
 	for i := uint(0); i < attempts; i++ {
 		err = f()
 		// Stop retrying if the call succeeded or if the context has been cancelled.
-		if err == nil || err != nil && errors.Is(err, context.Canceled) {
+		if err == nil || errors.Is(err, context.Canceled) {
 			break
 		}
 


### PR DESCRIPTION
Just a minor cosmetic fix, removing unnecessary tautological condition.