### PR TITLE
Fix product diff and removal of incomplete versions

### DIFF
--- a/simplestream-maintainer/cmd_build.go
+++ b/simplestream-maintainer/cmd_build.go
@@ -230,7 +230,7 @@ func buildProductCatalog(ctx context.Context, rootDir string, streamVersion stri
 
 				// Read the version and generate the file hashes.
 				versionPath := filepath.Join(productPath, versionName)
-				version, err := stream.GetVersion(rootDir, versionPath, true)
+				version, err := stream.GetVersion(rootDir, versionPath, stream.WithHashes(true))
 				if err != nil {
 					slog.Error("Failed to get version", "streamName", streamName, "product", id, "version", versionName, "error", err)
 					return
@@ -355,7 +355,7 @@ func buildProductCatalog(ctx context.Context, rootDir string, streamVersion stri
 					// the catalog.
 					if !deltaExists || deltaItem.SHA256 == "" {
 						deltaRelPath := filepath.Join(productRelPath, targetVerName, deltaName)
-						deltaItem, err := stream.GetItem(rootDir, deltaRelPath, true)
+						deltaItem, err := stream.GetItem(rootDir, deltaRelPath, stream.WithHashes(true))
 						if err != nil {
 							slog.Error("Failed to get existing delta item", "product", id, "version", targetVerName, "item", deltaName, "error", err)
 							return

--- a/simplestream-maintainer/cmd_prune.go
+++ b/simplestream-maintainer/cmd_prune.go
@@ -79,7 +79,7 @@ func pruneStreamProductVersions(rootDir string, streamVersion string, streamName
 	// Find versions that need to be discarded.
 	var discardVersions []string
 
-	for i, p := range catalog.Products {
+	for id, p := range catalog.Products {
 		productPath := filepath.Join(rootDir, streamName, p.RelPath())
 
 		versions := shared.MapKeys(p.Versions)
@@ -94,7 +94,7 @@ func pruneStreamProductVersions(rootDir string, streamVersion string, streamName
 		// Extract versions that need to be discarded.
 		discard := slices.Delete(versions, 0, retain)
 		for _, v := range discard {
-			delete(catalog.Products[i].Versions, v)
+			delete(catalog.Products[id].Versions, v)
 
 			versionPath := filepath.Join(productPath, v)
 			discardVersions = append(discardVersions, versionPath)
@@ -142,8 +142,8 @@ func pruneStreamProductVersions(rootDir string, streamVersion string, streamName
 // and prunes the product versions that are not referenced by the corresponding
 // product catalog.
 func pruneDanglingProductVersions(rootDir string, streamVersion string, streamName string) error {
-	// Get raw products (from actual directory hierarchy).
-	products, err := stream.GetProducts(rootDir, streamName)
+	// Get all products including incomplete (from actual directory hierarchy).
+	products, err := stream.GetProducts(rootDir, streamName, stream.WithIncompleteVersions(true))
 	if err != nil {
 		return err
 	}

--- a/simplestream-maintainer/stream/stream_test.go
+++ b/simplestream-maintainer/stream/stream_test.go
@@ -85,7 +85,7 @@ func TestGetItem(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			test.Mock.Create(t, t.TempDir())
 
-			item, err := stream.GetItem(test.Mock.RootDir(), test.Mock.RelPath(), test.CalcHash)
+			item, err := stream.GetItem(test.Mock.RootDir(), test.Mock.RelPath(), stream.WithHashes(test.CalcHash))
 			if test.WantErr != nil {
 				assert.ErrorIs(t, err, test.WantErr)
 			} else {
@@ -225,7 +225,7 @@ func TestGetVersion(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			test.Mock.Create(t, t.TempDir())
 
-			version, err := stream.GetVersion(test.Mock.RootDir(), test.Mock.RelPath(), test.CalcHashes)
+			version, err := stream.GetVersion(test.Mock.RootDir(), test.Mock.RelPath(), stream.WithHashes(test.CalcHashes))
 			if test.WantErr != nil {
 				assert.ErrorIs(t, err, test.WantErr)
 			} else {
@@ -591,9 +591,9 @@ func TestDoesNotExist(t *testing.T) {
 
 			switch test.Mock.(type) {
 			case testutils.ItemMock:
-				_, err = stream.GetItem(test.Mock.RootDir(), test.Mock.RelPath(), false)
+				_, err = stream.GetItem(test.Mock.RootDir(), test.Mock.RelPath())
 			case testutils.VersionMock:
-				_, err = stream.GetVersion(test.Mock.RootDir(), test.Mock.RelPath(), false)
+				_, err = stream.GetVersion(test.Mock.RootDir(), test.Mock.RelPath())
 			case testutils.ProductMock:
 				_, err = stream.GetProduct(test.Mock.RootDir(), test.Mock.RelPath())
 			default:


### PR DESCRIPTION
This PR includes some fixes detected during testing of the imageserver.

- Diff products

  There was an issue with product diffing due to the nested versions map within each product. 
When copying a product the map reference was copied as well, so diff products always returned all versions.

- Name field in Item struct

  This is not necessary, because item name can be retrieved from the map of items (keys).
When fetching a products from the catalog item names were empty because they are not included as a separate field in the catalog.

- Prune incomplete versions

  Incomplete versions were not pruned because they were not retrieved when calling GetProducts. This PR adds an option to include incomplete versions when retrieving products.