### PR TITLE
Fix product catalog ID

### DIFF
--- a/simplestream-maintainer/cmd_build.go
+++ b/simplestream-maintainer/cmd_build.go
@@ -182,7 +182,7 @@ func buildProductCatalog(ctx context.Context, rootDir string, streamVersion stri
 	}
 
 	if catalog == nil {
-		catalog = stream.NewCatalog(nil)
+		catalog = stream.NewCatalog(streamName, nil)
 	}
 
 	// Get existing products (from actual directory hierarchy).

--- a/simplestream-maintainer/cmd_test.go
+++ b/simplestream-maintainer/cmd_test.go
@@ -62,7 +62,7 @@ func TestBuildIndex(t *testing.T) {
 				testutils.MockVersion("2024_01_04").WithFiles("lxd.tar.xz", "disk.qcow2", "rootfs.squashfs"),
 			),
 			WantCatalog: stream.ProductCatalog{
-				ContentID: "images",
+				ContentID: "images-daily",
 				Format:    "products:1.0",
 				DataType:  "image-downloads",
 				Products: map[string]stream.Product{

--- a/simplestream-maintainer/stream/stream.go
+++ b/simplestream-maintainer/stream/stream.go
@@ -201,13 +201,13 @@ type ProductCatalog struct {
 }
 
 // NewCatalog creates a new product catalog.
-func NewCatalog(products map[string]Product) *ProductCatalog {
+func NewCatalog(streamName string, products map[string]Product) *ProductCatalog {
 	if products == nil {
 		products = make(map[string]Product)
 	}
 
 	return &ProductCatalog{
-		ContentID: "images",
+		ContentID: streamName,
 		DataType:  "image-downloads",
 		Format:    "products:1.0",
 		Products:  products,

--- a/simplestream-maintainer/testutils/testutils.go
+++ b/simplestream-maintainer/testutils/testutils.go
@@ -303,7 +303,7 @@ func mockProductCatalog(t *testing.T, rootDir string, streamName string) {
 	require.NoError(t, err)
 
 	// Create product catalog.
-	catalog := stream.NewCatalog(products)
+	catalog := stream.NewCatalog(streamName, products)
 	catalogPath := filepath.Join(metaDir, fmt.Sprintf("%s.json", streamName))
 
 	// Ensure catalog's directory exists.


### PR DESCRIPTION
Previously, content id was set to `images` for all product catalogs. Now it is set to the name of the stream (e.g. `images` or `images-daily`).

This change allows us to rebuild product paths for a landing page, without traversing deeper into version items (which include stream name when they are created).

In addition, if we ever support multiple catalogs (for example `archive`, `daily`, etc.) this would be required in order to differentiate catalogs in index.json.