### PR TITLE
Use `debootstrap --merged-usr` with Ubuntu Noble and Debian Sid

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
             ssh-keyscan git.launchpad.net >> ~/.ssh/known_hosts
             ssh-keygen -qlF git.launchpad.net | grep -xF 'git.launchpad.net RSA SHA256:UNOzlP66WpDuEo34Wgs8mewypV0UzqHLsIFoqwe8dYo'
 
-        - name: Install Go (${{ matrix.go }})
+        - name: Install Go
           uses: actions/setup-go@v5
           with:
             go-version: 1.22.x

--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -25,7 +25,7 @@ func (s *debootstrap) Run() error {
 	release := strings.ToLower(s.definition.Image.Release)
 
 	// Enable merged /usr by default, and disable it for certain distros/releases
-	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "debian" && slices.Contains([]string{"sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
+	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
 		args = append(args, "--no-merged-usr")
 	} else {
 		args = append(args, "--merged-usr")

--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -25,7 +25,7 @@ func (s *debootstrap) Run() error {
 	release := strings.ToLower(s.definition.Image.Release)
 
 	// Enable merged /usr by default, and disable it for certain distros/releases
-	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic", "noble"}, release) || distro == "debian" && slices.Contains([]string{"sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
+	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "debian" && slices.Contains([]string{"sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
 		args = append(args, "--no-merged-usr")
 	} else {
 		args = append(args, "--merged-usr")


### PR DESCRIPTION
This was successfully tested to build Ubuntu Noble desktop and Debian Sid (which was known broken before).