### PR TITLE
Prune products with no versions from the product catalog

### DIFF
--- a/simplestream-maintainer/cmd_build.go
+++ b/simplestream-maintainer/cmd_build.go
@@ -254,7 +254,7 @@ func buildProductCatalog(ctx context.Context, rootDir string, streamVersion stri
 		tmp := p
 
 		_, ok := catalog.Products[id]
-		if ok {
+		if ok && len(catalog.Products[id].Versions) > 0 {
 			// Retain existing product versions.
 			tmp.Versions = catalog.Products[id].Versions
 		} else {

--- a/simplestream-maintainer/cmd_prune.go
+++ b/simplestream-maintainer/cmd_prune.go
@@ -113,6 +113,11 @@ func pruneStreamProductVersions(rootDir string, streamVersion string, streamName
 				}
 			}
 		}
+
+		// Remove products that contain no versions.
+		if len(catalog.Products[id].Versions) == 0 {
+			delete(catalog.Products, id)
+		}
 	}
 
 	// Write product catalog to a temporary file that is located next


### PR DESCRIPTION
Panic was caused by products in an existing product catalog that do not contain `versions` field (meaning there is no actual image associated with the product).

This PR prevents the panic when catalog contains a product with no associated versions, and ensures that such products are also pruned from the catalog.

Fixes https://github.com/canonical/lxd/issues/13451