### PR TITLE
Do not make symlinks to /usr when debootstraping Debian

### DIFF
--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -25,7 +25,7 @@ func (s *debootstrap) Run() error {
 	release := strings.ToLower(s.definition.Image.Release)
 
 	// Enable merged /usr by default, and disable it for certain distros/releases
-	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
+	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "debian" && slices.Contains([]string{"sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
 		args = append(args, "--no-merged-usr")
 	} else {
 		args = append(args, "--merged-usr")

--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -25,7 +25,7 @@ func (s *debootstrap) Run() error {
 	release := strings.ToLower(s.definition.Image.Release)
 
 	// Enable merged /usr by default, and disable it for certain distros/releases
-	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "debian" && slices.Contains([]string{"sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
+	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "debian" && slices.Contains([]string{"trixie", "sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
 		args = append(args, "--no-merged-usr")
 	} else {
 		args = append(args, "--merged-usr")


### PR DESCRIPTION
Use debootstrap `--no-merged-usr` flag for Debian Trixie and Sid releases.

Passing build on fork using this change: https://github.com/MusicDin/lxd-ci/actions/runs/9581704461/job/26419094864