### PR TITLE
Improve readability of generated simplestream webpage

### DIFF
--- a/embed/templates/index.html
+++ b/embed/templates/index.html
@@ -99,6 +99,23 @@
             border-bottom: 0;
         }
 
+        .lxd-text-arch {
+            display: inline-block;
+            text-align: center;
+            width: 65px;
+            border-radius: 5px;
+            padding-left: 5px;
+            padding-right: 5px;
+        }
+
+        .lxd-text-arch.arm64 {
+            background-color: rgba(0, 127, 255, 0.3);
+        }
+
+        .lxd-text-arch.amd64 {
+            background-color: rgba(47, 130, 2, 0.3);
+        }
+
         .icon {
             background-repeat: no-repeat;
             display: inline-block;
@@ -202,7 +219,11 @@
                 <tr>
                     <td>{{ .Distribution }}</td>
                     <td>{{ .Release }}</td>
-                    <td>{{ .Architecture }}</td>
+                    <td>
+                        <div class="lxd-text-arch {{ .Architecture }}">
+                            {{ .Architecture }}
+                        </div>
+                    </td>
                     <td>{{ .Variant }}</td>
                     <td class="text-center"><i class="{{ if .SupportsContainer }}icon icon-ok{{ end }}"></i></td>
                     <td class="text-center"><i class="{{ if .SupportsVM }}icon icon-ok{{ end }}"></i></td>

--- a/embed/templates/index.html
+++ b/embed/templates/index.html
@@ -99,12 +99,62 @@
             border-bottom: 0;
         }
 
-        .icon-ok {
-            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="5bc137" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>');
+        .icon {
             background-repeat: no-repeat;
             display: inline-block;
             width: 1rem;
             height: 1rem;
+        }
+
+        .icon-ok {
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="5bc137" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"/></svg>');
+        }
+
+        .icon-warn {
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z"/></svg>');
+        }
+
+        .icon-tooltip {
+            visibility: hidden;
+            position: absolute;
+            color: #fff;
+            background-color: #333;
+            text-align: center;
+            border-radius: 5px;
+            z-index: 1;
+            bottom: 125%;
+            left: 50%;
+            width: 180px;
+            margin-left: -90px;
+            padding: 5px;
+            opacity: 0;
+            transition: opacity 0.4s;
+        }
+
+        /* Tooltip arrow */
+        .icon-tooltip::after {
+            content: "";
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            margin-left: -5px;
+            border-width: 5px;
+            border-style: solid;
+            border-color: #333 transparent transparent transparent; /* Arrow pointing up */
+        }
+
+        .icon-container {
+            position: relative;
+            display: inline-block;
+        }
+
+        .icon-container i {
+            cursor: pointer;
+        }
+
+        .icon-container:hover .icon-tooltip {
+            visibility: visible;
+            opacity: 1;
         }
     </style>
 </head>
@@ -145,6 +195,7 @@
                     <th class="table-secondary" scope="col">Variant</th>
                     <th class="table-secondary text-center" scope="col">Container</th>
                     <th class="table-secondary text-center" scope="col">Virtual Machine</th>
+                    <th class="" scope="col"></th><!-- Empty column for warnings-->
                     <th class="table-secondary text-end" scope="col">Last Build (UTC)</th>
                 </tr>
                 {{ range .Images }}
@@ -153,8 +204,14 @@
                     <td>{{ .Release }}</td>
                     <td>{{ .Architecture }}</td>
                     <td>{{ .Variant }}</td>
-                    <td class="text-center"><i class="{{ if .SupportsContainer }}icon-ok{{ end }}"></i></td>
-                    <td class="text-center"><i class="{{ if .SupportsVM }}icon-ok{{ end }}"></i></td>
+                    <td class="text-center"><i class="{{ if .SupportsContainer }}icon icon-ok{{ end }}"></i></td>
+                    <td class="text-center"><i class="{{ if .SupportsVM }}icon icon-ok{{ end }}"></i></td>
+                    <td class="text-end">
+                        <div class="icon-container">
+                            <i class="{{ if .IsStale }}icon icon-warn{{ end }}"></i>
+                            <span class="icon-tooltip">Last image build is older than 8 days.</span>
+                        </div>
+                    </td>
                     <td class="text-end"><a href="{{ .VersionPath }}">{{ .VersionLastBuildDate }}</a></td>
                 </tr>
                 {{ end }}

--- a/simplestream-maintainer/webpage/webpage.go
+++ b/simplestream-maintainer/webpage/webpage.go
@@ -23,6 +23,7 @@ type WebPageImage struct {
 	VersionLastBuildDate string
 	SupportsContainer    bool
 	SupportsVM           bool
+	IsStale              bool
 }
 
 // WebPage represents the data that will be used to populate the webpage template.
@@ -83,12 +84,17 @@ func NewWebPage(catalog stream.ProductCatalog) *WebPage {
 
 		// Converts timestamp from format "YYYYMMDD_hhmm" into a prettier
 		// format "YYYY-MM-DD (hh:mm)".
-		time, err := time.Parse("20060102_1504", last)
+		timestamp, err := time.Parse("20060102_1504", last)
 		if err != nil {
 			image.VersionLastBuildDate = "N/A"
 		} else {
-			image.VersionLastBuildDate = time.Format("2006-01-02 (15:04)")
+			image.VersionLastBuildDate = timestamp.UTC().Format("2006-01-02 (15:04)")
 			image.VersionPath = filepath.Join("/", catalog.ContentID, product.RelPath(), last)
+		}
+
+		// Image is considered stale if older than 8 days.
+		if timestamp.Before(time.Now().AddDate(0, 0, -8)) {
+			image.IsStale = true
 		}
 
 		// Iterate over version items and check if the image supports

--- a/simplestream-maintainer/webpage/webpage.go
+++ b/simplestream-maintainer/webpage/webpage.go
@@ -50,7 +50,7 @@ func NewWebPage(catalog stream.ProductCatalog) *WebPage {
 		FooterUpdatedAt: fmt.Sprintf("Last updated: %s UTC", time.Now().UTC().Format("02 Jan 2006 (15:04)")),
 		Paragraphs: []template.HTML{
 			template.HTML("Images hosted on this server are available in LXD through the predefined remote <code>images:</code>. For detailed instructions about LXD image management, please refer to our <a href='https://documentation.ubuntu.com/lxd/en/latest/howto/images_manage'>How to Manage Images</a> guide in the official documentation."),
-			template.HTML("Images are built daily and we retain the last 2 successful builds of each image for up to 10 days. Thus, if a particular build fails on any given day, the previous successful builds will remain accessible."),
+			template.HTML("Images are built daily and we retain the last 2 successful builds of each image for up to 15 days. Thus, if a particular build fails on any given day, the previous successful builds will remain accessible."),
 			template.HTML("If you encounter any issues with the images hosted on our server or have suggestions for improvement, please let us know by <a href='https://github.com/canonical/lxd/issues/new'>opening an issue</a> in the LXD repository."),
 		},
 		Images: []WebPageImage{},


### PR DESCRIPTION
Changes:
- Fix retention days in description (10 -> 15)
- Add warning if image is older than 8 days
- Separate arm64/amd64 architectures by adding different backgrounds

Preview:
<img width="1317" alt="image" src="https://github.com/canonical/lxd-imagebuilder/assets/56398240/5a5ff29e-7a7d-454d-8597-b8a793de1887">
