### PR TITLE
Kali linux no-merged-usr

### DIFF
--- a/sources/debootstrap.go
+++ b/sources/debootstrap.go
@@ -25,7 +25,7 @@ func (s *debootstrap) Run() error {
 	release := strings.ToLower(s.definition.Image.Release)
 
 	// Enable merged /usr by default, and disable it for certain distros/releases
-	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "debian" && slices.Contains([]string{"trixie", "sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" {
+	if distro == "ubuntu" && slices.Contains([]string{"xenial", "bionic"}, release) || distro == "debian" && slices.Contains([]string{"trixie", "sid"}, release) || distro == "mint" && slices.Contains([]string{"tara", "tessa", "tina", "tricia", "ulyana"}, release) || distro == "devuan" || distro == "kali" {
 		args = append(args, "--no-merged-usr")
 	} else {
 		args = append(args, "--merged-usr")


### PR DESCRIPTION
Same issue as recently for Debian trixie/sid. At the end, Kali is based on Debian. Therefore, set `--no-merged-usr` flag when deboostraping.

Debootstrap log when building kali linux:
```
tar: ./bin: Cannot create symlink to 'usr/bin': File exists
tar: ./lib: Cannot create symlink to 'usr/lib': File exists
tar: ./lib64: Cannot create symlink to 'usr/lib64': File exists
tar: ./sbin: Cannot create symlink to 'usr/sbin': File exists
tar: Exiting with failure status due to previous errors
```

Passing build: https://github.com/MusicDin/lxd-ci/actions/runs/9710853867/job/26802404331