### PR TITLE
Compact JSON

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -632,8 +632,6 @@ func WriteJSONFile(path string, obj any) error {
 	defer file.Close()
 
 	encoder := json.NewEncoder(file)
-	encoder.SetIndent("", "  ")
-
 	err = encoder.Encode(obj)
 	if err != nil {
 		return fmt.Errorf("Error encoding JSON: %w", err)

--- a/simplestream-maintainer/cmd_test.go
+++ b/simplestream-maintainer/cmd_test.go
@@ -155,10 +155,10 @@ func TestBuildIndex(t *testing.T) {
 			require.NoError(t, err, "Failed building index and catalog files!")
 
 			// Convert expected catalog and index files to json.
-			jsonCatalogExpect, err := json.MarshalIndent(test.WantCatalog, "", "  ")
+			jsonCatalogExpect, err := json.Marshal(test.WantCatalog)
 			require.NoError(t, err)
 
-			jsonIndexExpect, err := json.MarshalIndent(test.WantIndex, "", "  ")
+			jsonIndexExpect, err := json.Marshal(test.WantIndex)
 			require.NoError(t, err)
 
 			// Read actual catalog and index files.


### PR DESCRIPTION
The old community `images:` server used compact JSON. Let's do the same for the new `images:` one.

Today's `images.json` file weights around `416K` and shrinks to `291K` once compacted.