### PR TITLE
webpage: Image details

### DIFF
--- a/embed/templates/index.html
+++ b/embed/templates/index.html
@@ -130,6 +130,17 @@
             background-color: var(--color-codeblock);
         }
 
+        .lxd-text-codeblock-border {
+            display: inline-block;
+            text-align: center;
+            padding-left: 5px;
+            padding-right: 5px;
+            padding-top: 2px;
+            padding-left: 2px;
+            border-radius: 5px;
+            border: 1px solid var(--color-codeblock);
+        }
+
         .lxd-modal {
             min-width: 350px;
             border: 1px solid #111111;
@@ -329,6 +340,25 @@
                 </div>
                 <!-- Dialog: Body -->
                 <div class="modal-body">
+                    <div class="mt-3">
+                        <div class="d-flex justify-content-center">
+                            <code class="px-3 py-2 text-black lxd-text-codeblock-border">
+                            lxc launch
+                            {{ if eq $index 0 }}
+                                <!-- Only the latest version is referencable by alias -->
+                                images:<span class="lxd-text-primary">{{ index $image.Aliases 0 }}</span>
+                                <span>{{ if and $version.FingerprintContainer $version.FingerprintVM }} c1 [--vm]{{ else if $version.FingerprintVM }} v1 --vm{{ else }}c1{{ end }}</span>
+                            {{ else }}
+                                <!-- Use fingerprint for other versions -->
+                                {{ if $version.FingerprintContainer }}
+                                images:<span class="lxd-text-primary">{{ $version.FingerprintContainer }}</span> c1
+                                {{ else }}
+                                images:<span class="lxd-text-primary">{{ $version.FingerprintVM }}</span> v1 --vm
+                                {{ end}}
+                            {{ end }}
+                            </code>
+                        </div>
+                    </div>
                     <div class="mx-3 mt-3 row row-cols-1 row-cols-lg-2">
                         <div class="col mt-1">
                             <div class="py-2">

--- a/embed/templates/index.html
+++ b/embed/templates/index.html
@@ -15,6 +15,7 @@
             --color-dark: #333333;
             --color-text-primary: #111111;
             --color-text-secondary: #777777;
+            --color-codeblock: rgba(145, 149, 143, 0.3);;
         }
 
         body {
@@ -95,6 +96,14 @@
             border-bottom: 0;
         }
 
+        .lxd-text-primary {
+            color: var(--color-primary);
+        }
+
+        .lxd-text-secondary {
+            color: var(--color-text-secondary);
+        }
+
         .lxd-text-arch {
             display: inline-block;
             text-align: center;
@@ -112,6 +121,51 @@
             background-color: rgba(47, 130, 2, 0.3);
         }
 
+        .lxd-text-variant {
+            display: inline-block;
+            text-align: center;
+            padding-left: 5px;
+            padding-right: 5px;
+            border-radius: 5px;
+            background-color: var(--color-codeblock);
+        }
+
+        .lxd-modal {
+            min-width: 350px;
+            border: 1px solid #111111;
+            border-radius: 8px;
+            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+            font-family: 'Ubuntu';
+            font-size: 1.05rem;
+            color: var(--color-text-primary);
+            background-color: var(--color-light);
+        }
+
+        .lxd-modal::backdrop {
+            background: rgba(0, 0, 0, 0.5);
+        }
+
+        .lxd-modal-header {
+            color: #fff;
+            background-color: var(--color-dark);
+            box-shadow: var(--color-dark) 0px 0px 10px;
+        }
+
+        div[data-bs-toggle="modal"] span {
+            color: gray;
+            text-align: center;
+            background-color: transparent;
+            padding: 7px;
+            border-radius: 7px;
+            transition: all 0.3s ease;
+            cursor: pointer;
+        }
+
+        div[data-bs-toggle="modal"]:hover span {
+            background-color: #e0e0e0;
+            color: black;
+        }
+
         .icon {
             background-repeat: no-repeat;
             display: inline-block;
@@ -125,6 +179,10 @@
 
         .icon-warn {
             background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480H40c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24V296c0 13.3 10.7 24 24 24s24-10.7 24-24V184c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z"/></svg>');
+        }
+
+        .icon-fingerprint {
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M48 256C48 141.1 141.1 48 256 48c63.1 0 119.6 28.1 157.8 72.5c8.6 10.1 23.8 11.2 33.8 2.6s11.2-23.8 2.6-33.8C403.3 34.6 333.7 0 256 0C114.6 0 0 114.6 0 256l0 40c0 13.3 10.7 24 24 24s24-10.7 24-24l0-40zm458.5-52.9c-2.7-13-15.5-21.3-28.4-18.5s-21.3 15.5-18.5 28.4c2.9 13.9 4.5 28.3 4.5 43.1l0 40c0 13.3 10.7 24 24 24s24-10.7 24-24l0-40c0-18.1-1.9-35.8-5.5-52.9zM256 80c-19 0-37.4 3-54.5 8.6c-15.2 5-18.7 23.7-8.3 35.9c7.1 8.3 18.8 10.8 29.4 7.9c10.6-2.9 21.8-4.4 33.4-4.4c70.7 0 128 57.3 128 128l0 24.9c0 25.2-1.5 50.3-4.4 75.3c-1.7 14.6 9.4 27.8 24.2 27.8c11.8 0 21.9-8.6 23.3-20.3c3.3-27.4 5-55 5-82.7l0-24.9c0-97.2-78.8-176-176-176zM150.7 148.7c-9.1-10.6-25.3-11.4-33.9-.4C93.7 178 80 215.4 80 256l0 24.9c0 24.2-2.6 48.4-7.8 71.9C68.8 368.4 80.1 384 96.1 384c10.5 0 19.9-7 22.2-17.3c6.4-28.1 9.7-56.8 9.7-85.8l0-24.9c0-27.2 8.5-52.4 22.9-73.1c7.2-10.4 8-24.6-.2-34.2zM256 160c-53 0-96 43-96 96l0 24.9c0 35.9-4.6 71.5-13.8 106.1c-3.8 14.3 6.7 29 21.5 29c9.5 0 17.9-6.2 20.4-15.4c10.5-39 15.9-79.2 15.9-119.7l0-24.9c0-28.7 23.3-52 52-52s52 23.3 52 52l0 24.9c0 36.3-3.5 72.4-10.4 107.9c-2.7 13.9 7.7 27.2 21.8 27.2c10.2 0 19-7 21-17c7.7-38.8 11.6-78.3 11.6-118.1l0-24.9c0-53-43-96-96-96zm24 96c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 24.9c0 59.9-11 119.3-32.5 175.2l-5.9 15.3c-4.8 12.4 1.4 26.3 13.8 31s26.3-1.4 31-13.8l5.9-15.3C267.9 411.9 280 346.7 280 280.9l0-24.9z"/></svg>');
         }
 
         .icon-tooltip {
@@ -233,12 +291,106 @@
                             <span class="icon-tooltip">Last image build is older than 8 days.</span>
                         </div>
                     </td>
-                    <td class="text-end"><a href="{{ $version.Path }}">{{ $version.BuildDate }}</a></td>
+                    <td class="text-end">
+                        <a href="#modal-{{ $version.Path }}" data-bs-toggle="modal">{{ $version.BuildDate }}</a>
+                    </td>
                 </tr>
                 {{ end }}
             </table>
         </div>
     </div>
+    {{ range .Images }}
+    {{ $image := . }}
+    {{ range $index, $version := .Versions }}
+    <!-- Image details (dialog) for each version -->
+    <div class="modal" id="modal-{{ $version.Path }}" tabindex="-1">
+        <div class="modal-dialog modal-dialog-centered modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content lxd-modal">
+                <!-- Dialog: Header -->
+                <div class="modal-header lxd-modal-header border-0">
+                    <h5 class="modal-title">{{ $image.Distribution }} {{ $image.Release }} </h5>
+                    &ensp;
+                    <div class="lxd-text-variant">
+                        {{ $image.Variant }}
+                    </div>
+                    &ensp;
+                    <div class="lxd-text-arch {{ $image.Architecture }}">
+                        {{ $image.Architecture }}
+                    </div>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <!-- Dialog: Body -->
+                <div class="modal-body">
+                    <!-- Fingerprints -->
+                    <div class="col mt-1">
+                        <div class="py-2">
+                            <span class="fs-6 lxd-text-secondary">Fingerprints</span>
+                        </div>
+                        <div class="ps-1">
+                            {{ if $version.FingerprintContainer }}
+                            <div class="py-1 d-flex align-items-center">
+                                <i class="icon icon-fingerprint"></i>
+                                <code class="ps-2 text-black">{{ $version.FingerprintContainer }} (Container)</code>
+                            </div>
+                            {{ end}}
+                            {{ if $version.FingerprintVM }}
+                            <div class="py-1 d-flex align-items-center">
+                                <i class="icon icon-fingerprint"></i>
+                                <code class="ps-2 text-black">{{ $version.FingerprintVM }} (Virtual Machine)</code>
+                            </div>
+                            {{ end}}
+                        </div>
+                    </div>
+                    <!-- Image files -->
+                    <div class="table-responsive">
+                        <table class="table lxd-table mt-3">
+                            <thead>
+                                <tr>
+                                    <th class="table-secondary" scope="col">Filename</th>
+                                    <th class="table-secondary text-center" scope="col">Date (UTC)</th>
+                                    <th class="table-secondary text-end" scope="col">Size</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {{ range $version.Files }}
+                                <tr>
+                                    <td><a href="{{ .Path }}">{{ .Name }}</a></td>
+                                    <td class="text-center">{{ .Date }}</td>
+                                    <td class="text-end"><code class="text-black" data-bs-toggle="tooltip" title="{{ .SizeBytes }} bytes">{{ .Size }}</code></td>
+                                </tr>
+                            {{ end }}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <!-- Dialog: Footer -->
+                <div class="modal-footer lxd-footer d-flex flex-nowrap justify-content-between align-items-center text-center">
+                    <div class="col-md-2">
+                        <!-- Show button for previous version if index is not first element -->
+                        {{ if gt $index 0 }}
+                        <div class="p-1" data-bs-toggle="modal" data-bs-target="#modal-{{ (index $image.Versions (sub $index 1)).Path }}">
+                            <span class="text-nowrap">&#x3008;&emsp;Newer</span>
+                        </div>
+                        {{ end }}
+                    </div>
+                    <div class="p-1">
+                        <span>Version: <strong>{{ $version.BuildDate }}</strong> UTC</span>
+                    </div>
+                    <div class="col-md-2 align-items-center">
+                        <!-- Show button for next version if index is not last element -->
+                        {{ if lt $index (sub (len $image.Versions) 1) }}
+                        <div class="p-1" data-bs-toggle="modal" data-bs-target="#modal-{{ (index $image.Versions (add $index 1)).Path }}">
+                            <span class="text-nowrap">Older&emsp;&#x3009;</span>
+                        </div>
+                        {{ end }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {{ end }}
+    {{ end }}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js" integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy" crossorigin="anonymous"></script>
 </body>
 <footer>
     <hr>

--- a/embed/templates/index.html
+++ b/embed/templates/index.html
@@ -15,7 +15,7 @@
             --color-dark: #333333;
             --color-text-primary: #111111;
             --color-text-secondary: #777777;
-          }
+        }
 
         body {
             font-family: 'Ubuntu';
@@ -89,10 +89,6 @@
         .lxd-table tr td:last-child,
         .lxd-table tr th:last-child {
             padding-right: 15px;
-        }
-
-        .lxd-table tr:first-child td {
-            border-top: 10px solid var(--color-dark);
         }
 
         .lxd-table tr:last-child td {
@@ -175,7 +171,8 @@
         }
     </style>
 </head>
-<body class="lxd-bg-light">
+<body>
+    <!-- Header -->
     <div class="pb-3 lxd-header" >
         <div class="container">
             <div class="d-flex align-items-end">
@@ -184,6 +181,7 @@
             </div>
         </div>
     </div>
+    <!-- Content -->
     <div class="container mt-5 pt-5">
         <h2 class="mb-3">Image Server</h2>
         <div class="row justify-content-between" >
@@ -201,6 +199,7 @@
             </div>
         </div>
     </div>
+    <!-- Table of available images -->
     <div class="container align-items-center pb-5">
         <h2 class="mt-5" >Available Images</h2>
         <div class="table-responsive">
@@ -216,6 +215,7 @@
                     <th class="table-secondary text-end" scope="col">Last Build (UTC)</th>
                 </tr>
                 {{ range .Images }}
+                {{ $version := index .Versions 0 }} <!-- First element is latest version -->
                 <tr>
                     <td>{{ .Distribution }}</td>
                     <td>{{ .Release }}</td>
@@ -225,15 +225,15 @@
                         </div>
                     </td>
                     <td>{{ .Variant }}</td>
-                    <td class="text-center"><i class="{{ if .SupportsContainer }}icon icon-ok{{ end }}"></i></td>
-                    <td class="text-center"><i class="{{ if .SupportsVM }}icon icon-ok{{ end }}"></i></td>
+                    <td class="text-center"><i class="{{ if $version.FingerprintContainer }}icon icon-ok{{ end }}"></i></td>
+                    <td class="text-center"><i class="{{ if $version.FingerprintVM }}icon icon-ok{{ end }}"></i></td>
                     <td class="text-end">
                         <div class="icon-container">
-                            <i class="{{ if .IsStale }}icon icon-warn{{ end }}"></i>
+                            <i class="{{ if $version.IsStale }}icon icon-warn{{ end }}"></i>
                             <span class="icon-tooltip">Last image build is older than 8 days.</span>
                         </div>
                     </td>
-                    <td class="text-end"><a href="{{ .VersionPath }}">{{ .VersionLastBuildDate }}</a></td>
+                    <td class="text-end"><a href="{{ $version.Path }}">{{ $version.BuildDate }}</a></td>
                 </tr>
                 {{ end }}
             </table>

--- a/embed/templates/index.html
+++ b/embed/templates/index.html
@@ -185,6 +185,14 @@
             background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M48 256C48 141.1 141.1 48 256 48c63.1 0 119.6 28.1 157.8 72.5c8.6 10.1 23.8 11.2 33.8 2.6s11.2-23.8 2.6-33.8C403.3 34.6 333.7 0 256 0C114.6 0 0 114.6 0 256l0 40c0 13.3 10.7 24 24 24s24-10.7 24-24l0-40zm458.5-52.9c-2.7-13-15.5-21.3-28.4-18.5s-21.3 15.5-18.5 28.4c2.9 13.9 4.5 28.3 4.5 43.1l0 40c0 13.3 10.7 24 24 24s24-10.7 24-24l0-40c0-18.1-1.9-35.8-5.5-52.9zM256 80c-19 0-37.4 3-54.5 8.6c-15.2 5-18.7 23.7-8.3 35.9c7.1 8.3 18.8 10.8 29.4 7.9c10.6-2.9 21.8-4.4 33.4-4.4c70.7 0 128 57.3 128 128l0 24.9c0 25.2-1.5 50.3-4.4 75.3c-1.7 14.6 9.4 27.8 24.2 27.8c11.8 0 21.9-8.6 23.3-20.3c3.3-27.4 5-55 5-82.7l0-24.9c0-97.2-78.8-176-176-176zM150.7 148.7c-9.1-10.6-25.3-11.4-33.9-.4C93.7 178 80 215.4 80 256l0 24.9c0 24.2-2.6 48.4-7.8 71.9C68.8 368.4 80.1 384 96.1 384c10.5 0 19.9-7 22.2-17.3c6.4-28.1 9.7-56.8 9.7-85.8l0-24.9c0-27.2 8.5-52.4 22.9-73.1c7.2-10.4 8-24.6-.2-34.2zM256 160c-53 0-96 43-96 96l0 24.9c0 35.9-4.6 71.5-13.8 106.1c-3.8 14.3 6.7 29 21.5 29c9.5 0 17.9-6.2 20.4-15.4c10.5-39 15.9-79.2 15.9-119.7l0-24.9c0-28.7 23.3-52 52-52s52 23.3 52 52l0 24.9c0 36.3-3.5 72.4-10.4 107.9c-2.7 13.9 7.7 27.2 21.8 27.2c10.2 0 19-7 21-17c7.7-38.8 11.6-78.3 11.6-118.1l0-24.9c0-53-43-96-96-96zm24 96c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 24.9c0 59.9-11 119.3-32.5 175.2l-5.9 15.3c-4.8 12.4 1.4 26.3 13.8 31s26.3-1.4 31-13.8l5.9-15.3C267.9 411.9 280 346.7 280 280.9l0-24.9z"/></svg>');
         }
 
+        .icon-at {
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M256 64C150 64 64 150 64 256s86 192 192 192c17.7 0 32 14.3 32 32s-14.3 32-32 32C114.6 512 0 397.4 0 256S114.6 0 256 0S512 114.6 512 256l0 32c0 53-43 96-96 96c-29.3 0-55.6-13.2-73.2-33.9C320 371.1 289.5 384 256 384c-70.7 0-128-57.3-128-128s57.3-128 128-128c27.9 0 53.7 8.9 74.7 24.1c5.7-5 13.1-8.1 21.3-8.1c17.7 0 32 14.3 32 32l0 80 0 32c0 17.7 14.3 32 32 32s32-14.3 32-32l0-32c0-106-86-192-192-192zm64 192a64 64 0 1 0 -128 0 64 64 0 1 0 128 0z"/></svg>');
+        }
+
+        .icon-file {
+            background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M64 464c-8.8 0-16-7.2-16-16L48 64c0-8.8 7.2-16 16-16l160 0 0 80c0 17.7 14.3 32 32 32l80 0 0 288c0 8.8-7.2 16-16 16L64 464zM64 0C28.7 0 0 28.7 0 64L0 448c0 35.3 28.7 64 64 64l256 0c35.3 0 64-28.7 64-64l0-293.5c0-17-6.7-33.3-18.7-45.3L274.7 18.7C262.7 6.7 246.5 0 229.5 0L64 0zm56 256c-13.3 0-24 10.7-24 24s10.7 24 24 24l144 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-144 0zm0 96c-13.3 0-24 10.7-24 24s10.7 24 24 24l144 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-144 0z"/></svg>');
+        }
+
         .icon-tooltip {
             visibility: hidden;
             position: absolute;
@@ -321,27 +329,56 @@
                 </div>
                 <!-- Dialog: Body -->
                 <div class="modal-body">
-                    <!-- Fingerprints -->
-                    <div class="col mt-1">
-                        <div class="py-2">
-                            <span class="fs-6 lxd-text-secondary">Fingerprints</span>
+                    <div class="mx-3 mt-3 row row-cols-1 row-cols-lg-2">
+                        <div class="col mt-1">
+                            <div class="py-2">
+                                <!-- <i class="icon icon-fingerprint"></i> -->
+                                <span class="fs-6 lxd-text-secondary">Fingerprints</span>
+                            </div>
+                            <div class="ps-1">
+                                {{ if $version.FingerprintContainer }}
+                                <div class="py-1 d-flex align-items-center">
+                                    <i class="icon icon-fingerprint"></i>
+                                    <code class="ps-2 text-black">{{ $version.FingerprintContainer }} (Container)</code>
+                                </div>
+                                {{ end}}
+                                {{ if $version.FingerprintVM }}
+                                <div class="py-1 d-flex align-items-center">
+                                    <i class="icon icon-fingerprint"></i>
+                                    <code class="ps-2 text-black">{{ $version.FingerprintVM }} (Virtual Machine)</code>
+                                </div>
+                                {{ end}}
+                            </div>
                         </div>
-                        <div class="ps-1">
-                            {{ if $version.FingerprintContainer }}
-                            <div class="py-1 d-flex align-items-center">
-                                <i class="icon icon-fingerprint"></i>
-                                <code class="ps-2 text-black">{{ $version.FingerprintContainer }} (Container)</code>
+                        {{ if eq $index 0 }}
+                        <div class="col mt-1">
+                            <div class="py-2">
+                                <span class="fs-6 lxd-text-secondary">Aliases</span>
                             </div>
-                            {{ end}}
-                            {{ if $version.FingerprintVM }}
-                            <div class="py-1 d-flex align-items-center">
-                                <i class="icon icon-fingerprint"></i>
-                                <code class="ps-2 text-black">{{ $version.FingerprintVM }} (Virtual Machine)</code>
+                            {{ range $image.Aliases }}
+                            <div class="ps-1 py-1 d-flex align-items-center">
+                                <i class="icon icon-at"></i>
+                                <code class="ps-2 text-black">{{ . }}</code>
                             </div>
-                            {{ end}}
+                            {{ end }}
+                        </div>
+                        {{ end }}
+                    </div>
+                    <div class="mx-3 mt-2 row row-cols-1 row-cols-lg-2">
+                        <div class="col mt-1">
+                        {{ if gt (len $image.Requirements) 0 }}
+                            <div class="py-2">
+                                <span class="fs-6 lxd-text-secondary">Requirements</span>
+                            </div>
+                            {{ range $key, $value := $image.Requirements }}
+                            <div class="ps-1 py-1 d-flex align-items-center">
+                                <i class="icon icon-file"></i>
+                                <code class="ms-2 text-black">{{ $key }}={{ $value }}</code>
+                            </div>
+                            {{ end }}
+                        {{ end }}
                         </div>
                     </div>
-                    <!-- Image files -->
                     <div class="table-responsive">
                         <table class="table lxd-table mt-3">
                             <thead>

--- a/simplestream-maintainer/cmd_build.go
+++ b/simplestream-maintainer/cmd_build.go
@@ -122,7 +122,10 @@ func buildIndex(ctx context.Context, rootDir string, streamVersion string, strea
 
 		// Create webpage for the stream.
 		if buildWebpage {
-			indexHTML = webpage.NewWebPage(*catalog)
+			indexHTML, err = webpage.NewWebPage(rootDir, *catalog)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Add index entry.

--- a/simplestream-maintainer/webpage/webpage.go
+++ b/simplestream-maintainer/webpage/webpage.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"slices"
 	"time"
+	"unicode"
+
+	"github.com/canonical/lxd/shared/units"
 
 	"github.com/canonical/lxd-imagebuilder/embed"
 	"github.com/canonical/lxd-imagebuilder/shared"
@@ -142,4 +145,21 @@ func (p WebPage) Write(rootDir string) error {
 	}
 
 	return os.Rename(pathTmp, path)
+}
+
+// formatSize returns a human-readable string representation of the given size.
+func formatSize(sizeBytes int64, precision uint) string {
+	sizeStr := units.GetByteSizeString(sizeBytes, precision)
+
+	// Read the string backwards to find the first digit
+	// and add space between the number and the unit.
+	for i := len(sizeStr) - 1; i >= 0; i-- {
+		if unicode.IsDigit(rune(sizeStr[i])) {
+			number := sizeStr[:i+1]
+			unit := sizeStr[i+1:]
+			return number + " " + unit
+		}
+	}
+
+	return sizeStr
 }

--- a/simplestream-maintainer/webpage/webpage.go
+++ b/simplestream-maintainer/webpage/webpage.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 	"unicode"
 
@@ -47,6 +48,8 @@ type WebPageImage struct {
 	Architecture string
 	Variant      string
 	IsStale      bool
+	Aliases      []string
+	Requirements map[string]string
 
 	Versions []WebPageImageVersion
 }
@@ -99,10 +102,12 @@ func NewWebPage(rootDir string, catalog stream.ProductCatalog) (*WebPage, error)
 		}
 
 		image := WebPageImage{
+			Aliases:      strings.Split(product.Aliases, ","),
 			Distribution: product.OS,
 			Release:      product.Release,
 			Architecture: product.Architecture,
 			Variant:      product.Variant,
+			Requirements: product.Requirements,
 		}
 
 		// Sort version ids in reverse order, so that the first version

--- a/simplestream-maintainer/webpage/webpage.go
+++ b/simplestream-maintainer/webpage/webpage.go
@@ -91,7 +91,7 @@ func NewWebPage(catalog stream.ProductCatalog) *WebPage {
 		if err != nil {
 			image.VersionLastBuildDate = "N/A"
 		} else {
-			image.VersionLastBuildDate = timestamp.UTC().Format("2006-01-02 (15:04)")
+			image.VersionLastBuildDate = formatTime(timestamp)
 			image.VersionPath = filepath.Join("/", catalog.ContentID, product.RelPath(), last)
 		}
 
@@ -162,4 +162,9 @@ func formatSize(sizeBytes int64, precision uint) string {
 	}
 
 	return sizeStr
+}
+
+// formatTime returns a UTC time as string in format "YYYY-MM-DD (hh:mm)".
+func formatTime(time time.Time) string {
+	return time.UTC().Format("2006-01-02 (15:04)")
 }


### PR DESCRIPTION
Generates details view for each image version. Details include launch command, some basic information about the image (fingerprint, aliases, and potential requirements), and list of image files.

<img width="982" alt="image" src="https://github.com/user-attachments/assets/a2daf688-a095-4a7a-ad88-1b588c818bdb" />

<img width="979" alt="image" src="https://github.com/user-attachments/assets/ea2d9129-dc30-4d3d-a41c-21e53e3da9a6" />
