### PR TITLE
embed/templates: Fix variable reference in handlebars

### DIFF
--- a/embed/templates/index.html
+++ b/embed/templates/index.html
@@ -353,7 +353,7 @@
                                 {#unless version.hasPrevious}
                                     <!-- Only the latest version is referencable by alias -->
                                     images:<span class="lxd-text-primary">{#each aliases}{#if @first}{ this }{/if}{/each}</span>
-                                    <span>{#if version.FingerprintContainer} c1{#if version.FingerprintVM} [--vm]{/if}{else}{#if $version.FingerprintVM} v1 --vm{else}c1{/if}{/if}</span>
+                                    <span>{#if version.FingerprintContainer} c1{#if version.FingerprintVM} [--vm]{/if}{else}{#if version.FingerprintVM} v1 --vm{else}c1{/if}{/if}</span>
                                 {else}
                                     <!-- Use fingerprint for other versions -->
                                     {#if version.FingerprintContainer}


### PR DESCRIPTION
Fix incorrect variable reference within handlebars. The extra `$` that is left from Go template caused incorrect launch commands where containers are not supported.

Previously:
<img width="642" alt="image" src="https://github.com/user-attachments/assets/bbb28cf4-a9a5-4383-a9b3-5c6567a655eb" />

Now:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/4b3b2945-b9a4-4f3a-95a2-7419e2a8ffe6" />
