### PR TITLE
fedora: Build images from OCI tarball instead of ISO image

### DIFF
--- a/sources/fedora-http.go
+++ b/sources/fedora-http.go
@@ -73,13 +73,13 @@ func (s *fedora) Run() error {
 			return fmt.Errorf("Failed to create OCI path: %q: %w", ociDir, err)
 		}
 
-		_, err = lxdShared.RunCommand("umoci", "unpack", "--keep-dirlinks", "--image", fmt.Sprintf("%s:fedora:%s", filepath.Join(ociDir, "image"), s.definition.Image.Release), filepath.Join(ociDir, "content"))
+		_, err = lxdShared.RunCommandContext(s.ctx, "umoci", "unpack", "--keep-dirlinks", "--image", fmt.Sprintf("%s:fedora:%s", filepath.Join(ociDir, "image"), s.definition.Image.Release), filepath.Join(ociDir, "content"))
 		if err != nil {
 			return fmt.Errorf("Failed to run umoci: %w", err)
 		}
 
 		// Transfer the content.
-		_, err = lxdShared.RunCommand("rsync", "-avP", fmt.Sprintf("%s/rootfs/", filepath.Join(ociDir, "content")), s.rootfsDir)
+		_, err = lxdShared.RunCommandContext(s.ctx, "rsync", "-avP", fmt.Sprintf("%s/rootfs/", filepath.Join(ociDir, "content")), s.rootfsDir)
 		if err != nil {
 			return fmt.Errorf("Failed to run rsync: %w", err)
 		}

--- a/sources/fedora-http.go
+++ b/sources/fedora-http.go
@@ -9,7 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
+
+	lxdShared "github.com/canonical/lxd/shared"
 
 	"github.com/canonical/lxd-imagebuilder/shared"
 )
@@ -20,7 +23,14 @@ type fedora struct {
 
 // Run downloads a container base image and unpacks it and its layers.
 func (s *fedora) Run() error {
-	baseURL := fmt.Sprintf("%s/packages/Fedora-Container-Base", s.definition.Source.URL)
+	base := "Fedora-Container-Base-Generic"
+	extension := "oci.tar.xz"
+	if slices.Contains([]string{"39", "40"}, s.definition.Image.Release) {
+		base = "Fedora-Container-Base"
+		extension = "tar.xz"
+	}
+
+	baseURL := fmt.Sprintf("%s/packages/%s", s.definition.Source.URL, base)
 
 	// Get latest build
 	build, err := s.getLatestBuild(baseURL, s.definition.Image.Release)
@@ -28,8 +38,7 @@ func (s *fedora) Run() error {
 		return fmt.Errorf("Failed to get latest build: %w", err)
 	}
 
-	fname := fmt.Sprintf("Fedora-Container-Base-%s-%s.%s.tar.xz",
-		s.definition.Image.Release, build, s.definition.Image.ArchitectureMapped)
+	fname := fmt.Sprintf("%s-%s-%s.%s.%s", base, s.definition.Image.Release, build, s.definition.Image.ArchitectureMapped, extension)
 
 	// Download image
 	sourceURL := fmt.Sprintf("%s/%s/%s/images/%s", baseURL, s.definition.Image.Release, build, fname)
@@ -41,18 +50,59 @@ func (s *fedora) Run() error {
 
 	s.logger.WithField("file", filepath.Join(fpath, fname)).Info("Unpacking image")
 
-	// Unpack the base image
-	err = shared.Unpack(filepath.Join(fpath, fname), s.rootfsDir)
-	if err != nil {
-		return fmt.Errorf("Failed to unpack %q: %w", filepath.Join(fpath, fname), err)
-	}
+	if extension == "oci.tar.xz" {
+		// Unpack the OCI image.
+		ociDir, err := os.MkdirTemp(s.getTargetDir(), "oci.")
+		if err != nil {
+			return fmt.Errorf("Failed to create OCI path: %q: %w", ociDir, err)
+		}
 
-	s.logger.Info("Unpacking layers")
+		err = os.Mkdir(filepath.Join(ociDir, "image"), 0755)
+		if err != nil {
+			return fmt.Errorf("Failed to create OCI path: %q: %w", ociDir, err)
+		}
 
-	// Unpack the rest of the image (/bin, /sbin, /usr, etc.)
-	err = s.unpackLayers(s.rootfsDir)
-	if err != nil {
-		return fmt.Errorf("Failed to unpack: %w", err)
+		err = shared.Unpack(filepath.Join(fpath, fname), filepath.Join(ociDir, "image"))
+		if err != nil {
+			return fmt.Errorf("Failed to unpack %q: %w", filepath.Join(fpath, fname), err)
+		}
+
+		// Extract the image to a temporary path.
+		err = os.Mkdir(filepath.Join(ociDir, "content"), 0755)
+		if err != nil {
+			return fmt.Errorf("Failed to create OCI path: %q: %w", ociDir, err)
+		}
+
+		_, err = lxdShared.RunCommand("umoci", "unpack", "--keep-dirlinks", "--image", fmt.Sprintf("%s:fedora:%s", filepath.Join(ociDir, "image"), s.definition.Image.Release), filepath.Join(ociDir, "content"))
+		if err != nil {
+			return fmt.Errorf("Failed to run umoci: %w", err)
+		}
+
+		// Transfer the content.
+		_, err = lxdShared.RunCommand("rsync", "-avP", fmt.Sprintf("%s/rootfs/", filepath.Join(ociDir, "content")), s.rootfsDir)
+		if err != nil {
+			return fmt.Errorf("Failed to run rsync: %w", err)
+		}
+
+		// Delete the temporary directory.
+		err = os.RemoveAll(ociDir)
+		if err != nil {
+			return fmt.Errorf("Failed to wipe OCI directory: %w", err)
+		}
+	} else {
+		// Handle simple rootfs tarballs.
+		err = shared.Unpack(filepath.Join(fpath, fname), s.rootfsDir)
+		if err != nil {
+			return fmt.Errorf("Failed to unpack %q: %w", filepath.Join(fpath, fname), err)
+		}
+
+		s.logger.Info("Unpacking layers")
+
+		// Unpack the rest of the image (/bin, /sbin, /usr, etc.)
+		err = s.unpackLayers(s.rootfsDir)
+		if err != nil {
+			return fmt.Errorf("Failed to unpack: %w", err)
+		}
 	}
 
 	return nil

--- a/sources/fedora-http.go
+++ b/sources/fedora-http.go
@@ -1,7 +1,6 @@
 package sources
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,87 +10,49 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
-	"strings"
 
 	"github.com/canonical/lxd-imagebuilder/shared"
 )
 
 type fedora struct {
-	commonRHEL
+	common
 }
 
 // Run downloads a container base image and unpacks it and its layers.
 func (s *fedora) Run() error {
-	// For backwards compatibility, fallback to manual URL construction
-	// when the release version is equal or less than 40.
-	relNum, err := strconv.Atoi(s.definition.Image.Release)
-	if err == nil && relNum <= 40 {
-		baseURL := fmt.Sprintf("%s/packages/Fedora-Container-Base", s.definition.Source.URL)
+	baseURL := fmt.Sprintf("%s/packages/Fedora-Container-Base", s.definition.Source.URL)
 
-		// Get latest build
-		build, err := s.getLatestBuild(baseURL, s.definition.Image.Release)
-		if err != nil {
-			return fmt.Errorf("Failed to get latest build: %w", err)
-		}
-
-		fname := fmt.Sprintf("Fedora-Container-Base-%s-%s.%s.tar.xz", s.definition.Image.Release, build, s.definition.Image.ArchitectureMapped)
-
-		// Download image
-		sourceURL := fmt.Sprintf("%s/%s/%s/images/%s", baseURL, s.definition.Image.Release, build, fname)
-
-		fpath, err := s.DownloadHash(s.definition.Image, sourceURL, "", nil)
-		if err != nil {
-			return fmt.Errorf("Failed to download %q: %w", sourceURL, err)
-		}
-
-		s.logger.WithField("file", filepath.Join(fpath, fname)).Info("Unpacking image")
-
-		// Unpack the base image
-		err = shared.Unpack(filepath.Join(fpath, fname), s.rootfsDir)
-		if err != nil {
-			return fmt.Errorf("Failed to unpack %q: %w", filepath.Join(fpath, fname), err)
-		}
-
-		s.logger.Info("Unpacking layers")
-
-		// Unpack the rest of the image (/bin, /sbin, /usr, etc.)
-		err = s.unpackLayers(s.rootfsDir)
-		if err != nil {
-			return fmt.Errorf("Failed to unpack: %w", err)
-		}
-
-		return nil
-	}
-
-	// Otherwise, get the ISO image URL from the available releases.
-	sourceURL, checksum, err := s.getDownloadURL(s.definition.Image.Release, s.definition.Image.Variant, s.definition.Image.ArchitectureMapped, ".iso")
+	// Get latest build
+	build, err := s.getLatestBuild(baseURL, s.definition.Image.Release)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to get latest build: %w", err)
 	}
 
-	if checksum == "" {
-		return fmt.Errorf("Checksum not found for %q", sourceURL)
-	}
+	fname := fmt.Sprintf("Fedora-Container-Base-%s-%s.%s.tar.xz",
+		s.definition.Image.Release, build, s.definition.Image.ArchitectureMapped)
+
+	// Download image
+	sourceURL := fmt.Sprintf("%s/%s/%s/images/%s", baseURL, s.definition.Image.Release, build, fname)
 
 	fpath, err := s.DownloadHash(s.definition.Image, sourceURL, "", nil)
 	if err != nil {
 		return fmt.Errorf("Failed to download %q: %w", sourceURL, err)
 	}
 
-	fname := filepath.Join(fpath, filepath.Base(sourceURL))
-
-	err = shared.VerifyChecksum(fname, checksum, sha256.New())
-	if err != nil {
-		return fmt.Errorf("Failed to verify checksum: %w", err)
-	}
-
-	s.logger.WithField("file", fname).Info("Unpacking image")
+	s.logger.WithField("file", filepath.Join(fpath, fname)).Info("Unpacking image")
 
 	// Unpack the base image
-	err = s.unpackISO(fname, s.rootfsDir, s.isoRunner)
+	err = shared.Unpack(filepath.Join(fpath, fname), s.rootfsDir)
 	if err != nil {
-		return fmt.Errorf("Failed to unpack %q: %w", fname, err)
+		return fmt.Errorf("Failed to unpack %q: %w", filepath.Join(fpath, fname), err)
+	}
+
+	s.logger.Info("Unpacking layers")
+
+	// Unpack the rest of the image (/bin, /sbin, /usr, etc.)
+	err = s.unpackLayers(s.rootfsDir)
+	if err != nil {
+		return fmt.Errorf("Failed to unpack: %w", err)
 	}
 
 	return nil
@@ -212,125 +173,4 @@ func (s *fedora) getLatestBuild(URL string, release string) (string, error) {
 
 	// Return latest build
 	return matches[len(matches)-1], nil
-}
-
-// getDownloadURL fetches JSON representation of current releases and
-// extracts the download URL matching the given release, variant, arch,
-// and filetype (.tar.xz, .iso, etc.).
-func (s *fedora) getDownloadURL(release string, variant string, arch string, fileType string) (url string, checksum string, err error) {
-	releasesURL := "https://fedoraproject.org/releases.json"
-	s.logger.Infof("Querying %q for list of available releases", releasesURL)
-
-	// Fetch available releases.
-	resp, err := http.Get(releasesURL)
-	if err != nil {
-		return "", "", fmt.Errorf("Failed to fetch releases from %q: %w", releasesURL, err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("Unexpected status code %q from %q: %w", resp.StatusCode, releasesURL, err)
-	}
-
-	// Parse JSON response.
-	var result []struct {
-		Release    string `json:"version"`
-		Arch       string `json:"arch"`
-		Variant    string `json:"variant"`
-		Subvariant string `json:"subvariant"`
-		URL        string `json:"link"`
-		SHA256     string `json:"sha256"`
-		SizeBytes  string `json:"size"`
-	}
-
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	if err != nil {
-		return "", "", fmt.Errorf("Failed to parse JSON response: %w", err)
-	}
-
-	// Variant mapping.
-	// Default to variant "Container" and subvariant "Container_Base".
-	var subvariant string
-	if variant == "default" || variant == "cloud" {
-		variant = "Server"
-		subvariant = "Server"
-	}
-
-	// Iterate over response items and find the matching image.
-	for _, item := range result {
-		if item.Release != release || item.Arch != arch || item.Variant != variant {
-			continue
-		}
-
-		if subvariant != "" && item.Subvariant != subvariant {
-			continue
-		}
-
-		if !strings.HasSuffix(item.URL, fileType) {
-			continue
-		}
-
-		// Matching URL found.
-		return item.URL, item.SHA256, nil
-	}
-
-	return "", "", fmt.Errorf("Failed to find download URL for release %q, variant %q, arch %q, and file type %q", release, variant, arch, fileType)
-}
-
-func (s *fedora) isoRunner(gpgkeys string) error {
-	err := shared.RunScript(s.ctx, fmt.Sprintf(`#!/bin/sh
-set -eux
-
-# Create required files
-touch /etc/mtab /etc/fstab
-
-dnf_args=""
-mkdir -p /etc/yum.repos.d
-
-# Add cdrom repo
-cat <<- EOF > /etc/yum.repos.d/cdrom.repo
-[cdrom]
-name=Install CD-ROM
-baseurl=file:///mnt/cdrom
-enabled=0
-EOF
-
-GPG_KEYS="%s"
-
-gpg_keys_official="file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-%[2]s-primary"
-
-if [ -n "${GPG_KEYS}" ]; then
-	echo gpgcheck=1 >> /etc/yum.repos.d/cdrom.repo
-	echo gpgkey=${gpg_keys_official} ${GPG_KEYS} >> /etc/yum.repos.d/cdrom.repo
-else
-	echo gpgcheck=0 >> /etc/yum.repos.d/cdrom.repo
-fi
-
-dnf_args="--disablerepo=* --enablerepo=cdrom"
-
-# Newest install.img doesnt have rpm installed,
-# so first install rpm.
-if ! command -v rpmkeys; then
-	cd /mnt/cdrom/Packages
-	dnf ${dnf_args} -y install rpm
-fi
-
-pkgs="basesystem fedora-release dnf"
-
-# Create a minimal rootfs
-mkdir /rootfs
-dnf ${dnf_args} --installroot=/rootfs --releasever=%[2]s -y install ${pkgs}
-rm -rf /rootfs/var/cache/yum
-rm -rf /rootfs/var/cache/dnf
-rm -rf /etc/yum.repos.d/cdrom.repo
-# Remove all files in mnt packages
-rm -rf /mnt/cdrom
-`, gpgkeys, s.definition.Image.Release))
-
-	if err != nil {
-		return fmt.Errorf("Failed to run script: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
Replaces building Fedora 41+ images from ISO with building from an OCI tarball.

Cherry-picked https://github.com/lxc/distrobuilder/pull/886

Passing build: https://github.com/MusicDin/lxd-ci/actions/runs/13308568809/job/37165117942