### PR TITLE
Update linter config and address linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,28 @@
+version: "2"
 linters:
   enable:
-    - gofmt
-    - misspell
-    - godot
-    - whitespace
-    - gci
     - errorlint
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/canonical/lxd-imagebuilder)
+    - godot
+    - misspell
+    - whitespace
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: "ST1005:" # ST1005: error strings should not be capitalized
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/canonical/lxd-imagebuilder)

--- a/generators/fstab.go
+++ b/generators/fstab.go
@@ -33,7 +33,6 @@ LABEL=UEFI    /boot/efi vfat  defaults  0 0
 `
 
 	fs := target.VM.Filesystem
-
 	if fs == "" {
 		fs = "ext4"
 	}
@@ -44,7 +43,7 @@ LABEL=UEFI    /boot/efi vfat  defaults  0 0
 		options = fmt.Sprintf("%s,subvol=@", options)
 	}
 
-	_, err = f.WriteString(fmt.Sprintf(content, fs, options))
+	_, err = fmt.Fprintf(f, content, fs, options)
 	if err != nil {
 		return fmt.Errorf("Failed to write string to file %q: %w", filepath.Join(g.sourceDir, "etc/fstab"), err)
 	}

--- a/generators/hosts.go
+++ b/generators/hosts.go
@@ -31,7 +31,7 @@ func (g *hosts) RunLXC(img *image.LXCImage, target shared.DefinitionTargetLXC) e
 	}
 
 	// Replace hostname with placeholder
-	content = []byte(strings.Replace(string(content), "lxd-imagebuilder", "LXC_NAME", -1))
+	content = []byte(strings.ReplaceAll(string(content), "lxd-imagebuilder", "LXC_NAME"))
 
 	// Add a new line if needed
 	if !strings.Contains(string(content), "LXC_NAME") {
@@ -82,7 +82,7 @@ func (g *hosts) RunLXD(img *image.LXDImage, target shared.DefinitionTargetLXD) e
 	}
 
 	// Replace hostname with placeholder
-	content = []byte(strings.Replace(string(content), "lxd-imagebuilder", "{{ container.name }}", -1))
+	content = []byte(strings.ReplaceAll(string(content), "lxd-imagebuilder", "{{ container.name }}"))
 
 	// Add a new line if needed
 	if !strings.Contains(string(content), "{{ container.name }}") {

--- a/image/lxc.go
+++ b/image/lxc.go
@@ -55,7 +55,7 @@ func (l *LXCImage) AddTemplate(path string) error {
 
 	defer file.Close()
 
-	_, err = file.WriteString(fmt.Sprintf("%v\n", path))
+	_, err = fmt.Fprintf(file, "%v\n", path)
 	if err != nil {
 		return fmt.Errorf("Failed to write to template file: %w", err)
 	}

--- a/managers/equo.go
+++ b/managers/equo.go
@@ -42,9 +42,10 @@ func (m *equo) load() error {
 }
 
 func (m *equo) manageRepository(repoAction shared.DefinitionPackagesRepository) error {
-	if repoAction.Type == "" || repoAction.Type == "equo" {
+	switch repoAction.Type {
+	case "", "equo":
 		return m.equoRepoCaller(repoAction)
-	} else if repoAction.Type == "enman" {
+	case "enman":
 		return m.enmanRepoCaller(repoAction)
 	}
 

--- a/managers/manager.go
+++ b/managers/manager.go
@@ -142,9 +142,10 @@ func (m *Manager) ManagePackages(imageTarget shared.ImageTarget) error {
 	}
 
 	for _, set := range optimizePackageSets(validSets) {
-		if set.Action == "install" {
+		switch set.Action {
+		case "install":
 			err = m.mgr.install(set.Packages, set.Flags)
-		} else if set.Action == "remove" {
+		case "remove":
 			err = m.mgr.remove(set.Packages, set.Flags)
 		}
 

--- a/shared/chroot.go
+++ b/shared/chroot.go
@@ -276,9 +276,10 @@ func SetupChroot(rootfs string, definition Definition, m []ChrootMount) (func() 
 	if len(envs.EnvVariables) > 0 {
 		imageTargets := ImageTargetUndefined | ImageTargetAll
 
-		if definition.Targets.Type == DefinitionFilterTypeContainer {
+		switch definition.Targets.Type {
+		case DefinitionFilterTypeContainer:
 			imageTargets |= ImageTargetContainer
-		} else if definition.Targets.Type == DefinitionFilterTypeVM {
+		case DefinitionFilterTypeVM:
 			imageTargets |= ImageTargetVM
 		}
 

--- a/sources/common.go
+++ b/sources/common.go
@@ -49,7 +49,7 @@ func (s *common) init(ctx context.Context, logger *logrus.Logger, definition sha
 
 func (s *common) getTargetDir() string {
 	dir := filepath.Join(s.sourcesDir, fmt.Sprintf("%s-%s-%s", s.definition.Image.Distribution, s.definition.Image.Release, s.definition.Image.ArchitectureMapped))
-	dir = strings.Replace(dir, " ", "", -1)
+	dir = strings.ReplaceAll(dir, " ", "")
 	dir = strings.ToLower(dir)
 
 	return dir

--- a/sources/funtoo-http.go
+++ b/sources/funtoo-http.go
@@ -22,13 +22,14 @@ type funtoo struct {
 // Run downloads a Funtoo stage3 tarball.
 func (s *funtoo) Run() error {
 	topLevelArch := s.definition.Image.ArchitectureMapped
-	if topLevelArch == "generic_32" {
+	switch topLevelArch {
+	case "generic_32":
 		topLevelArch = "x86-32bit"
-	} else if topLevelArch == "generic_64" {
+	case "generic_64":
 		topLevelArch = "x86-64bit"
-	} else if topLevelArch == "armv7a_vfpv3_hardfp" {
+	case "armv7a_vfpv3_hardfp":
 		topLevelArch = "arm-32bit"
-	} else if topLevelArch == "arm64_generic" {
+	case "arm64_generic":
 		topLevelArch = "arm-64bit"
 	}
 

--- a/sources/oraclelinux-http.go
+++ b/sources/oraclelinux-http.go
@@ -49,9 +49,10 @@ func (s *oraclelinux) Run() error {
 			latestUpdate = fmt.Sprintf("u%d", i)
 
 			if s.definition.Image.Release == "9" {
-				if s.architecture == "x86_64" {
+				switch s.architecture {
+				case "x86_64":
 					fname = fmt.Sprintf("OracleLinux-R9-U%d-%s-boot.iso", i, s.architecture)
-				} else if s.architecture == "aarch64" {
+				case "aarch64":
 					fname = fmt.Sprintf("OracleLinux-R9-U%d-%s-dvd.iso", i, s.architecture)
 				}
 			}
@@ -374,11 +375,12 @@ EOF
 func (s *oraclelinux) getISO(URL string, architecture string) (string, error) {
 	var re *regexp.Regexp
 
-	if architecture == "x86_64" {
+	switch architecture {
+	case "x86_64":
 		re = regexp.MustCompile(fmt.Sprintf("%s-boot(-\\d{8})?.iso", architecture))
-	} else if architecture == "aarch64" {
+	case "aarch64":
 		re = regexp.MustCompile(fmt.Sprintf("%s-boot-uek(-\\d{8})?.iso", architecture))
-	} else {
+	default:
 		return "", fmt.Errorf("Unsupported architecture %q", architecture)
 	}
 

--- a/sources/slackware-http.go
+++ b/sources/slackware-http.go
@@ -29,13 +29,14 @@ func (s *slackware) Run() error {
 	slackpkgPath := ""
 
 	// set mirror path based on architecture
-	if s.definition.Image.ArchitectureMapped == "i586" {
+	switch s.definition.Image.ArchitectureMapped {
+	case "i586":
 		mirrorPath = path.Join(u.Path, fmt.Sprintf("slackware-%s", s.definition.Image.Release), "slackware")
 		slackpkgPath = s.definition.Source.URL + fmt.Sprintf("slackware-%s", s.definition.Image.Release)
-	} else if s.definition.Image.ArchitectureMapped == "x86_64" {
+	case "x86_64":
 		mirrorPath = path.Join(u.Path, fmt.Sprintf("slackware64-%s", s.definition.Image.Release), "slackware64")
 		slackpkgPath = s.definition.Source.URL + fmt.Sprintf("slackware64-%s", s.definition.Image.Release)
-	} else {
+	default:
 		return fmt.Errorf("Invalid architecture: %s", s.definition.Image.Architecture)
 	}
 
@@ -150,7 +151,7 @@ func (s *slackware) downloadFiles(def shared.DefinitionImage, URL string, requir
 			pkgName := strings.Split(target, "-")[0]
 			twoPkgName := strings.Split(target, "-")[0] + "-" + strings.Split(target, "-")[1]
 
-			if !((slices.Contains(requiredPkgs, pkgName)) || (slices.Contains(requiredPkgs, twoPkgName))) {
+			if !slices.Contains(requiredPkgs, pkgName) && !slices.Contains(requiredPkgs, twoPkgName) {
 				continue
 			}
 


### PR DESCRIPTION
Update golangci-lint config to `v2.0.0`.

Addresses linter issues:
- Use ReplaceAll instead of Replace without a limit
- Use switch statements instead of else-ifs where applicable
- Use de morgan's law to simplify conditions