### PR TITLE
sources/openeuler: Sort found releases to pick the latest service pack

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,6 @@ jobs:
           sudo apt-get -qq update
           sudo apt-get install -y --no-install-recommends squashfs-tools xdelta3
 
-      - name: Update Go modules
-        run: make update-gomod
-
       - name: Run static analysis
         run: make static-analysis
 

--- a/sources/openeuler-http.go
+++ b/sources/openeuler-http.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/canonical/lxd-imagebuilder/shared"
@@ -51,6 +52,7 @@ func (s *openEuler) getLatestRelease(baseURL, release string) (string, error) {
 	releases := regex.FindAllString(string(body), -1)
 
 	if len(releases) > 0 {
+		slices.Sort(releases)
 		return strings.TrimPrefix(releases[len(releases)-1], "openEuler-"), nil
 	}
 


### PR DESCRIPTION
Instead of always taking the `LTS` release we want to pick latest service pack for an LTS - for example `LTS-SP4`