### PR TITLE
go: Bump min version to 1.24.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=$(shell grep "var Version" shared/version/version.go | cut -d'"' -f2)
 ARCHIVE=lxd-imagebuilder-$(VERSION).tar
 GO111MODULE=on
 SPHINXENV=.sphinx/venv/bin/activate
-GO_MIN=1.24.2
+GO_MIN=1.24.4
 
 .PHONY: default
 default:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To compile from source, first install the Go programming language, and some othe
     sudo pacman -S go debootstrap rsync gnupg squashfs-tools git make xdelta3 --needed
     ```
 
-NOTE: Go 1.24.2 or higher is required. If your package manager doesn't provide a recent enough
+NOTE: Go 1.24.4 or higher is required. If your package manager doesn't provide a recent enough
 version, [get it from upstream](https://go.dev/doc/install).
 
 Second, download the source code of the `lxd-imagebuilder` repository (this repository).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd-imagebuilder
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/canonical/lxd v0.0.0-20250319130657-21ebaba86623


### PR DESCRIPTION
Fixes failed tests in https://github.com/canonical/lxd-imagebuilder/pull/181