### PR TITLE
README: snap install from latest/edge requires `--edge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The `lxd-imagebuilder` and `simplestream-maintainer` tools are available in the 
 snap from the [Snap Store](https://snapcraft.io/lxd-imagebuilder).
 
 ```
-sudo snap install lxd-imagebuilder --classic
+sudo snap install lxd-imagebuilder --classic --edge
 ```
 
 ## Installing from source


### PR DESCRIPTION
Otherwise you're not able to copy/paste the command directly.