### PR TITLE
simplestream-maintainer: Improve errors and prevent prune from failing on invalid reference

### DIFF
--- a/simplestream-maintainer/cmd_prune.go
+++ b/simplestream-maintainer/cmd_prune.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -99,13 +100,21 @@ func pruneStreamProductVersions(rootDir string, streamVersion string, streamName
 				continue
 			}
 
-			// Remove versions older then retainDays.
-			if retainDays > 0 {
-				info, err := os.Stat(versionPath)
-				if err != nil {
-					return err
+			// If catalog references a non-existing version, remove it from the catalog
+			// and continue with the rest of versions.
+			info, err := os.Stat(versionPath)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					slog.Warn("Dropping stale product version from catalog", "path", versionPath)
+					delete(catalog.Products[id].Versions, v)
+					continue
 				}
 
+				return err
+			}
+
+			// Remove versions older then retainDays.
+			if retainDays > 0 {
 				maxAge := time.Duration(retainDays) * 24 * time.Hour
 				if time.Since(info.ModTime()) > maxAge {
 					delete(catalog.Products[id].Versions, v)

--- a/simplestream-maintainer/cmd_test.go
+++ b/simplestream-maintainer/cmd_test.go
@@ -612,6 +612,37 @@ func TestPruneOldVersions(t *testing.T) {
 	}
 }
 
+func TestPruneOldVersions_MissingVersionDirInCatalog(t *testing.T) {
+	t.Parallel()
+
+	// Create product directory structure and initial product catalog.
+	p := testutils.MockProduct("images/ubuntu/noble/amd64/cloud").
+		AddVersions(
+			testutils.MockVersion("2026_01_01").WithFiles("lxd.tar.xz", "disk.qcow2"),
+			testutils.MockVersion("2026_01_02").WithFiles("lxd.tar.xz", "disk.qcow2")).
+		AddProductCatalog()
+	p.Create(t, t.TempDir())
+
+	// Simulate stale catalog state by deleting one existing version directory.
+	missingVersion := "2026_01_01"
+	err := os.RemoveAll(filepath.Join(p.AbsPath(), missingVersion))
+	require.NoError(t, err)
+
+	// Prune should not fail when catalog references a missing version path.
+	err = pruneStreamProductVersions(p.RootDir(), "v1", p.StreamName(), 10, 1)
+	require.NoError(t, err)
+
+	catalogPath := filepath.Join(p.RootDir(), "streams", "v1", fmt.Sprintf("%s.json", p.StreamName()))
+	catalog, err := shared.ReadJSONFile(catalogPath, &stream.ProductCatalog{})
+	require.NoError(t, err)
+
+	// Ensure version missing on disk is removed from catalog.
+	productID := strings.Join(strings.Split(p.RelPath(), "/")[1:], ":")
+	require.Contains(t, catalog.Products, productID)
+	require.Contains(t, catalog.Products[productID].Versions, "2026_01_02")
+	require.NotContains(t, catalog.Products[productID].Versions, missingVersion)
+}
+
 func TestPruneDanglingResources(t *testing.T) {
 	t.Parallel()
 

--- a/simplestream-maintainer/stream/stream.go
+++ b/simplestream-maintainer/stream/stream.go
@@ -462,14 +462,14 @@ func GetVersion(rootDir string, versionRelPath string, options ...Option) (*Vers
 			checksumPath := filepath.Join(versionPath, file.Name())
 			version.Checksums, err = ReadChecksumFile(checksumPath)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to read checksums file: %w", err)
+				return nil, fmt.Errorf("Failed reading checksums file %q: %w", checksumPath, err)
 			}
 		} else if file.Name() == FileImageConfig {
 			// Read the image config file.
 			configPath := filepath.Join(versionPath, file.Name())
 			config, err := shared.ReadYAMLFile(configPath, &shared.Definition{})
 			if err != nil {
-				return nil, fmt.Errorf("%w: %w", ErrVersionInvalidImageConfig, err)
+				return nil, fmt.Errorf("Failed reading image config %q: %w: %w", configPath, ErrVersionInvalidImageConfig, err)
 			}
 
 			version.ImageConfig = config.Simplestream
@@ -599,6 +599,11 @@ func ReadChecksumFile(path string) (map[string]string, error) {
 		filename := strings.TrimSpace(parts[1])
 
 		checksums[filename] = checksum
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return nil, err
 	}
 
 	return checksums, nil


### PR DESCRIPTION
This PR:
- Fix prune command to remove references from catalog if they do not exist.
  If `retainDays` is set, prune tries to read version directory to determine its modification date. However, if directory no longer existed, prune failed. Now, prune removes invalid reference from catalog and continues (also logs a warning).
- Also includes file path in image parsing and checksum parsing errors.

