### PR TITLE
github: add `timeout` to commands interacting with external services

### DIFF
--- a/.github/actions/image-setup/action.yml
+++ b/.github/actions/image-setup/action.yml
@@ -38,8 +38,8 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        sudo apt-get -qq update
-        sudo apt-get install -y --no-install-recommends \
+        timeout 10m sudo apt-get -qq update
+        timeout 10m sudo apt-get install -y --no-install-recommends \
             build-essential \
             bzip2 \
             debootstrap \
@@ -61,7 +61,7 @@ runs:
         SNAP_CHANNEL: ${{ inputs.lxd-imagebuilder-channel }}
       shell: bash
       run: |
-        sudo snap install lxd-imagebuilder --channel="${SNAP_CHANNEL}" --classic
+        timeout 10m sudo snap install lxd-imagebuilder --channel="${SNAP_CHANNEL}" --classic
         lxd-imagebuilder --version
 
     - name: Setup LXD ${{ inputs.lxd-channel }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           set -eux
           if ! command -v yamllint > /dev/null; then
-            sudo apt-get update
-            sudo apt-get install --no-install-recommends -y yamllint
+            timeout 10m sudo apt-get update
+            timeout 10m sudo apt-get install --no-install-recommends -y yamllint
           fi
 
           find .github/ -type f -regex '.*\.ya?ml$' -exec yamllint --strict {} +

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,8 +59,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -qq update
-          sudo apt-get install -y --no-install-recommends squashfs-tools xdelta3
+          timeout 10m sudo apt-get -qq update
+          timeout 10m sudo apt-get install -y --no-install-recommends squashfs-tools xdelta3
 
       - name: Unit tests (all)
         run: make check


### PR DESCRIPTION
When Ubuntu archives or the snapstore have pathologically slow network throughput, those steps can burn through the 6 hours limit imposed on GitHub Action Runners.