### PR TITLE
github: add MusicDin and simondeziel as code owners for images

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @tomponline
+
+/images/ @tomponline @MusicDin @simondeziel
+/.github/workflows/image-*.yml @tomponline @MusicDin @simondeziel


### PR DESCRIPTION
Add @MusicDin and @simondeziel as code owners for image definitions and image-related workflows alongside @tomponline.